### PR TITLE
「=」タップ時の動作の追加。

### DIFF
--- a/lib/calculation.dart
+++ b/lib/calculation.dart
@@ -53,7 +53,12 @@ class CalcSystem {
           _result /= _number[ i++ ];
         }
       }
-      return _result.toString();
+      _number.clear();
+      _op.clear();
+      _numberBuffer = '';
+
+      var resultStr = _result.toString().split('.');
+      return resultStr[1] == '0' ? resultStr[0] : _result.toString();
   }
 }
 

--- a/lib/textfield.dart
+++ b/lib/textfield.dart
@@ -18,7 +18,7 @@ class MainDisplay extends StatefulWidget {
 //_expressionというString(テキストデータ)出力用の箱を突っ込みます。
 class DisplayController extends State<MainDisplay> {
   String _expression = '';
-  static final controller = StreamController<String>();
+  static final controller = StreamController.broadcast();
 //updateTextというボタンが押された時の関数の箱を作る
   void updateText(String letter) {
     setState(() {
@@ -61,6 +61,7 @@ class DisplayController extends State<MainDisplay> {
     super.initState();
     //controllerが動作を確認（Listen）したら内容をみてupdateTextを実行する。
     controller.stream.listen((event) => updateText(event));
+    controller.stream.listen((event) => CalcSystem.getKey(event));
   }
   @override
   void dispose() {


### PR DESCRIPTION
# 「=」タップ後に計算関数を実行したい。
## ■Streamに反応して計算してほしい
> static final controller = StreamController.broadcast();

を記載し、CalcSystem内のgetKey()を実施するようにtextfield.dartを変更。

## ■_resultへ計算結果を格納、その他のリストを空にしてほしい

小数点を省略するように調整をする。
> var resultStr = _result.toString().split('.');
    return resultStr[1] == '0' ? resultStr[0] : _result.toString();

その他のリストを空にする。
> _number.clear();
   _op.clear();
   _numberBuffer = '';

## ■ここまでで作成した関数の動作
![Frame 2](https://user-images.githubusercontent.com/78635923/167139639-eb951834-ff5c-43f8-be75-50086518b151.png)

## ■計算がうまくいかない
今後、修正予定。

https://user-images.githubusercontent.com/78635923/167140213-8617a7ee-df76-41b8-893d-601f06a741bd.mov


